### PR TITLE
Fix build on kernel 5.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # 
 MAKE_HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 ARCH ?= arm
-LOC_VERS := $(wildcard /lib/modules/*/build)
-LOC_VERS := $(patsubst %/,%,$(dir $(LOC_VERS)))
+LOC_VERS := $(wildcard /lib/modules/*/build/Makefile)
+LOC_VERS := $(patsubst %/build/,%,$(dir $(LOC_VERS)))
 LOC_VERS := $(notdir $(LOC_VERS))
 
 all: 

--- a/build/buildroot-2019.08-x86_64/Makefile
+++ b/build/buildroot-2019.08-x86_64/Makefile
@@ -1,7 +1,15 @@
 BUILDROOT_VER=buildroot-2019.08
 
+ifeq ($(PACKAGE_TOP),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+	PACKAGE_TOP=$(EPICS_PACKAGE_TOP)
+else
+	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided by the environment or on the command line)
+endif
+endif
+
 MAKE_HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-BUILDROOT_HOME = /afs/slac/package/linuxRT/$(BUILDROOT_VER)
+BUILDROOT_HOME = $(PACKAGE_TOP)/linuxRT/$(BUILDROOT_VER)
 ARCH=x86_64
 OUTPUT_DIR=../../buildroot-2019.08-x86_64
 


### PR DESCRIPTION
* Improved Makefile to only build for kernel versions that have a makefile in /usr/src
* `HAVE_UNLOCKED_IOCTL` was removed in kernel 5.9 as it has become default. So, we just define that if kernel version is >= 5.9
* `ioremap_nocache` was renamed to `ioremap` in kernel 5.5
* `vm_fault` return value was changed to `vm_fault_t` in one of the 4.x kernel versions. In 4.17, they typedef'ed it to `unsigned int` to break compiles if not migrated yet. 
* Removed old-style GNU designated initializers and replaced them with C99 designated initializers.